### PR TITLE
op-node/rollup: remove redundant nil check in engine_queue

### DIFF
--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -546,9 +546,6 @@ func (eq *EngineQueue) tryNextUnsafePayload(ctx context.Context) error {
 }
 
 func (eq *EngineQueue) tryNextSafeAttributes(ctx context.Context) error {
-	if eq.safeAttributes == nil { // sanity check the attributes are there
-		return nil
-	}
 	// validate the safe attributes before processing them. The engine may have completed processing them through other means.
 	if eq.safeHead != eq.safeAttributes.parent {
 		// Previously the attribute's parent was the safe head. If the safe head advances so safe head's parent is the same as the


### PR DESCRIPTION
`tryNextSafeAttributes` is only used in func `func (eq *EngineQueue) Step`, and already check in  `func (eq *EngineQueue) Step`